### PR TITLE
feat(mobile-admin): 簡易記事入力フォームに開始/終了時刻（任意）を追加

### DIFF
--- a/admin/css/mobile.css
+++ b/admin/css/mobile.css
@@ -229,6 +229,12 @@ body {
   margin-left: 2px;
 }
 
+.optional {
+  color: #888;
+  font-size: 0.75em;
+  font-weight: normal;
+}
+
 .form-input,
 .form-textarea {
   width: 100%;

--- a/admin/js/mobile-admin.js
+++ b/admin/js/mobile-admin.js
@@ -678,6 +678,8 @@ class MobileAdmin {
     const title = document.getElementById('new-title').value.trim();
     const dateFrom = document.getElementById('new-date-from').value;
     const dateTo = document.getElementById('new-date-to').value;
+    const timeFrom = document.getElementById('new-time-from').value;
+    const timeTo = document.getElementById('new-time-to').value;
     const summary = document.getElementById('new-summary').value.trim();
     const contentText = document.getElementById('new-content').value.trim();
     const excerpt = document.getElementById('new-excerpt').value.trim();
@@ -695,6 +697,10 @@ class MobileAdmin {
       this.showAlert('要約を入力してください', 'error');
       return;
     }
+    if (timeTo && !dateTo) {
+      this.showAlert('終了時刻を指定する場合は終了日も入力してください', 'error');
+      return;
+    }
 
     this.showLoading('記事を保存中...');
 
@@ -703,9 +709,26 @@ class MobileAdmin {
       ? contentText.split('\n').filter(l => l.trim()).map(l => `<p>${this.escapeHtml(l)}</p>`).join('')
       : '';
 
-    // 日時組み立て
-    const eventStartDatetime = dateFrom + ' 00:00:00';
-    const eventEndDatetime = dateTo ? dateTo + ' 23:59:59' : null;
+    // 日時組み立て（PC版 article-editor.js と同一ロジック）
+    const hasStartTime = timeFrom ? true : false;
+    const hasEndTime = timeTo ? true : false;
+
+    let eventStartDatetime = dateFrom;
+    if (hasStartTime) {
+      eventStartDatetime += ' ' + timeFrom + ':00';
+    } else {
+      eventStartDatetime += ' 00:00:00';
+    }
+
+    let eventEndDatetime = null;
+    if (dateTo) {
+      eventEndDatetime = dateTo;
+      if (hasEndTime) {
+        eventEndDatetime += ' ' + timeTo + ':00';
+      } else {
+        eventEndDatetime += ' 23:59:59';
+      }
+    }
 
     const articleData = {
       title,
@@ -715,8 +738,8 @@ class MobileAdmin {
       status: 'draft',
       event_start_datetime: eventStartDatetime,
       event_end_datetime: eventEndDatetime,
-      has_start_time: false,
-      has_end_time: false,
+      has_start_time: hasStartTime,
+      has_end_time: hasEndTime,
       featured_image_url: this.uploadedImageUrl || null,
       line_published: false,
       x_published: false,
@@ -743,6 +766,8 @@ class MobileAdmin {
     this.removeImage();
     document.getElementById('new-content').value = '';
     document.getElementById('new-excerpt').value = '';
+    document.getElementById('new-time-from').value = '';
+    document.getElementById('new-time-to').value = '';
   }
 
   // ============================

--- a/admin/mobile.html
+++ b/admin/mobile.html
@@ -47,6 +47,16 @@
                         <input type="date" id="new-date-to" class="form-input">
                     </div>
                 </div>
+                <div class="date-row" style="margin-top: 10px;">
+                    <div>
+                        <label class="form-label">開始時刻 <span class="optional">（任意）</span></label>
+                        <input type="time" id="new-time-from" class="form-input" placeholder="HH:MM">
+                    </div>
+                    <div>
+                        <label class="form-label">終了時刻 <span class="optional">（任意）</span></label>
+                        <input type="time" id="new-time-to" class="form-input" placeholder="HH:MM">
+                    </div>
+                </div>
             </div>
 
             <!-- 件名 -->

--- a/terraform/lambda/news_detail_page_generator/lambda_function.py
+++ b/terraform/lambda/news_detail_page_generator/lambda_function.py
@@ -314,7 +314,11 @@ def generate_detail_html(template: str, article: Dict[str, Any], attachments: Li
     # イベント日時
     event_start = article.get('event_start_datetime')
     event_end = article.get('event_end_datetime')
-    event_datetime_formatted = format_event_datetime(event_start, event_end) if event_start else ''
+    has_start_time = bool(article.get('has_start_time'))
+    has_end_time = bool(article.get('has_end_time'))
+    event_datetime_formatted = format_event_datetime(
+        event_start, event_end, has_start_time, has_end_time
+    ) if event_start else ''
 
     # SEO関連
     meta_title = article.get('meta_title') or title
@@ -533,21 +537,29 @@ def format_date_jp(iso_date: str) -> str:
         return iso_date
 
 
-def format_event_datetime(start: str, end: Optional[str]) -> str:
+def format_event_datetime(
+    start: str,
+    end: Optional[str],
+    has_start_time: bool = False,
+    has_end_time: bool = False,
+) -> str:
     """
     イベント日時をフォーマット
+
+    has_start_time/has_end_time が False の場合、対応する時刻部分（HH:MM）は出力しない。
     """
     try:
         start_dt = parse_datetime(start)
-        formatted = format_datetime_jp(start_dt)
+        formatted = format_datetime_jp(start_dt, include_time=has_start_time)
 
         if end:
             end_dt = parse_datetime(end)
-            # 同じ日の場合は終了時刻のみ
             if start_dt.date() == end_dt.date():
-                formatted += f" 〜 {end_dt.strftime('%H:%M')}"
+                # 同日: 終了時刻フラグありなら「〜 HH:MM」のみ追記。フラグなしなら何も追記しない
+                if has_end_time:
+                    formatted += f" 〜 {end_dt.strftime('%H:%M')}"
             else:
-                formatted += f" 〜 {format_datetime_jp(end_dt)}"
+                formatted += f" 〜 {format_datetime_jp(end_dt, include_time=has_end_time)}"
 
         return formatted
     except Exception:
@@ -568,13 +580,18 @@ def parse_datetime(iso_str: str) -> datetime:
         return datetime.fromisoformat(iso_str + 'T00:00:00')
 
 
-def format_datetime_jp(dt: datetime) -> str:
+def format_datetime_jp(dt: datetime, include_time: bool = True) -> str:
     """
     datetimeを日本語形式に変換
+
+    include_time=False の場合は「YYYY年M月D日（曜）」のみ。既定値 True で従来動作と互換。
     """
     weekdays = ['月', '火', '水', '木', '金', '土', '日']
     weekday = weekdays[dt.weekday()]
-    return f"{dt.year}年{dt.month}月{dt.day}日（{weekday}）{dt.strftime('%H:%M')}"
+    base = f"{dt.year}年{dt.month}月{dt.day}日（{weekday}）"
+    if include_time:
+        return base + dt.strftime('%H:%M')
+    return base
 
 
 def extract_description(content: str) -> str:


### PR DESCRIPTION
## Summary

モバイル版管理画面の簡易記事入力フォームに、開始日・終了日それぞれに **時刻（任意）** を入力できるようにしました。記事HTML生成側（Lambda）も時刻フラグに応じて表示有無を切り替えます。

- **入力**: `開始時刻` `終了時刻` を `<input type="time">` で追加（任意）。`終了時刻` 入力時は `終了日` 必須のバリデーションを追加。
- **保存**: 時刻が入力されていれば `has_start_time` / `has_end_time` を `true` で保存。datetime 文字列もPC版（`admin/js/article-editor.js` 1214-1233）と同一ロジックで組み立て。
- **HTML出力**: `format_event_datetime` に `has_start_time` / `has_end_time` 引数を追加。フラグ false なら `HH:MM` を出力しない。`format_datetime_jp` に `include_time` 引数（デフォルト True で従来互換）を追加。
- **後方互換**: 既存記事で `has_start_time/has_end_time` が NULL の場合、`bool(None)=False` で時刻なし表示となるため安全。Lambda 関数の他の呼び出し箇所は無く、影響範囲は閉じている。

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `admin/mobile.html` | 時刻入力2行を追加 |
| `admin/css/mobile.css` | `.optional` クラス追加 |
| `admin/js/mobile-admin.js` | `saveNewArticle` / `resetForm` にtime対応 |
| `terraform/lambda/news_detail_page_generator/lambda_function.py` | 時刻フラグ対応 |

## エージェント協業

- **設計者**: PC版の挙動踏襲、UIは2行構成（日付/時刻）、Lambdaは引数追加方針
- **実装者**: 設計通り4ファイルを修正
- **テスター**: 全10ケース（時刻あり/なし、同日/異日、NULL互換、バリデーション）コードレベル追跡で全PASS
- **レビュワー**: Comment（マージ可、軽微指摘のみ）

## Test plan

- [ ] モバイル管理画面で時刻なし記事を新規作成 → 詳細HTMLに `2026年4月20日（月）` のみ表示
- [ ] 開始時刻のみ入力 → `2026年4月20日（月）13:30`
- [ ] 同日 開始/終了時刻あり → `2026年4月20日（月）13:30 〜 17:00`
- [ ] 異日 開始/終了時刻あり → `2026年4月20日（月）13:30 〜 2026年4月22日（水）17:00`
- [ ] 終了時刻のみ入力（終了日なし）→ バリデーションエラー
- [ ] 既存記事（has_start_time NULL）→ 時刻なし表示で互換維持
- [ ] Lambda デプロイ（terraform apply 等）

https://claude.ai/code/session_015KYmSZffbQLGzyPaGaRCHX